### PR TITLE
Add the ability to display nested renderings with bindCompose.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
@@ -38,6 +37,9 @@ buildscript {
   }
 }
 
+// See https://stackoverflow.com/questions/25324880/detect-ide-environment-with-gradle
+val isRunningFromIde get() = project.properties["android.injected.invoked.from.ide"] == "true"
+
 subprojects {
   repositories {
     google()
@@ -60,7 +62,10 @@ subprojects {
 
   tasks.withType<KotlinCompile>() {
     kotlinOptions {
-      kotlinOptions.allWarningsAsErrors = true
+      // Allow warnings when running from IDE, makes it easier to experiment.
+      if (!isRunningFromIde) {
+        allWarningsAsErrors = true
+      }
 
       jvmTarget = "1.8"
 

--- a/core-compose/api/core-compose.api
+++ b/core-compose/api/core-compose.api
@@ -21,6 +21,11 @@ public final class com/squareup/workflow/ui/compose/ComposeViewFactory : com/squ
 	public fun getType ()Lkotlin/reflect/KClass;
 }
 
+public final class com/squareup/workflow/ui/compose/ViewEnvironmentsKt {
+	public static final fun showRendering (Lcom/squareup/workflow/ui/ViewEnvironment;Ljava/lang/Object;Landroidx/ui/core/Modifier;Landroidx/compose/Composer;)V
+	public static synthetic fun showRendering$default (Lcom/squareup/workflow/ui/ViewEnvironment;Ljava/lang/Object;Landroidx/ui/core/Modifier;Landroidx/compose/Composer;ILjava/lang/Object;)V
+}
+
 public final class com/squareup/workflow/ui/core/compose/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z

--- a/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeViewFactory.kt
+++ b/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeViewFactory.kt
@@ -56,17 +56,30 @@ import kotlin.reflect.KClass
  *
  * val viewRegistry = ViewRegistry(FooBinding, …)
  * ```
+ *
+ * ## Nesting child renderings
+ *
+ * Workflows can render other workflows, and renderings from one workflow can contain renderings
+ * from other workflows. These renderings may all be bound to their own [ViewFactory]s. Regular
+ * [ViewFactory]s and `LayoutRunner`s use
+ * [WorkflowViewStub][com.squareup.workflow.ui.WorkflowViewStub] to recursively show nested
+ * renderings using the [ViewRegistry][com.squareup.workflow.ui.ViewRegistry].
+ *
+ * View factories defined using this function may also show nested renderings. Doing so is as simple
+ * as calling [ViewEnvironment.showRendering] and passing in the nested rendering. See the kdoc on
+ * that function for an example.
  */
 inline fun <reified RenderingT : Any> bindCompose(
-  noinline showRendering: @Composable() (RenderingT, ViewEnvironment) -> Unit
-): ViewFactory<RenderingT> = ComposeViewFactory(RenderingT::class) { rendering, environment ->
-  showRendering(rendering, environment)
-}
+  noinline showRendering: @Composable() (
+    rendering: RenderingT,
+    environment: ViewEnvironment
+  ) -> Unit
+): ViewFactory<RenderingT> = ComposeViewFactory(RenderingT::class, showRendering)
 
 @PublishedApi
 internal class ComposeViewFactory<RenderingT : Any>(
   override val type: KClass<RenderingT>,
-  private val showRendering: @Composable() (RenderingT, ViewEnvironment) -> Unit
+  internal val showRendering: @Composable() (RenderingT, ViewEnvironment) -> Unit
 ) : ViewFactory<RenderingT> {
 
   override fun buildView(

--- a/core-compose/src/main/java/com/squareup/workflow/ui/compose/ViewEnvironments.kt
+++ b/core-compose/src/main/java/com/squareup/workflow/ui/compose/ViewEnvironments.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.ui.compose
+
+import androidx.compose.Composable
+import androidx.compose.remember
+import androidx.ui.core.Modifier
+import com.squareup.workflow.ui.ViewEnvironment
+import com.squareup.workflow.ui.ViewRegistry
+
+/**
+ * Renders [rendering] into the composition using this [ViewEnvironment]'s
+ * [ViewRegistry][com.squareup.workflow.ui.ViewRegistry] to generate the view.
+ *
+ * This function fulfills a similar role as
+ * [WorkflowViewStub][com.squareup.workflow.ui.WorkflowViewStub], but is much more convenient to use
+ * from Composable functions.
+ *
+ * ## Example
+ *
+ * ```
+ * data class FramedRendering(
+ *   val borderColor: Color,
+ *   val child: Any
+ * )
+ *
+ * val FramedContainerViewFactory = bindCompose<FramedRendering> { rendering, environment ->
+ *   Surface(border = Border(rendering.borderColor, 8.dp)) {
+ *     environment.showRendering(rendering.child)
+ *   }
+ * }
+ * ```
+ *
+ * @param rendering The workflow rendering to display. May be of any type for which a
+ * [ViewFactory][com.squareup.workflow.ui.ViewFactory] has been registered in this
+ * environment's [ViewRegistry].
+ * @param modifier A [Modifier] that will be applied to composable used to show [rendering].
+ *
+ * @throws IllegalArgumentException if no factory can be found for [rendering]'s type.
+ */
+@Composable fun ViewEnvironment.showRendering(
+  rendering: Any,
+  modifier: Modifier = Modifier
+) {
+  val viewRegistry = remember(this) { this[ViewRegistry] }
+  viewRegistry.showRendering(rendering, this, modifier)
+}

--- a/core-compose/src/main/java/com/squareup/workflow/ui/compose/ViewFactories.kt
+++ b/core-compose/src/main/java/com/squareup/workflow/ui/compose/ViewFactories.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.ui.compose
+
+import android.content.Context
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.widget.FrameLayout
+import androidx.compose.Composable
+import androidx.ui.core.Modifier
+import androidx.ui.foundation.Box
+import com.squareup.workflow.ui.ViewEnvironment
+import com.squareup.workflow.ui.ViewFactory
+import com.squareup.workflow.ui.WorkflowViewStub
+import com.squareup.workflow.ui.compose.ComposableViewStubWrapper.Update
+
+/**
+ * Renders [rendering] into the composition using the `ViewRegistry` from the [ViewEnvironment] to
+ * determine how to draw it.
+ *
+ * To display a nested rendering from a [Composable view binding][bindCompose], use
+ * [ViewEnvironment.showRendering].
+ *
+ * @see ViewEnvironment.showRendering
+ * @see com.squareup.workflow.ui.ViewRegistry.showRendering
+ */
+// Bug: IR compiler pukes on ViewFactory<RenderingT> here.
+@Composable internal fun <RenderingT : Any> ViewFactory<Any>.showRendering(
+  rendering: RenderingT,
+  viewEnvironment: ViewEnvironment,
+  modifier: Modifier = Modifier
+) {
+  Box(modifier = modifier) {
+    // Fast path: If the child binding is also a Composable, we don't need to go through the legacy
+    // view system and can just invoke the binding's composable function directly.
+    if (this is ComposeViewFactory) {
+      showRendering(rendering, viewEnvironment)
+    } else {
+      // IntelliJ currently complains very loudly about this function call, but it actually compiles.
+      // The IDE tooling isn't currently able to recognize that the Compose compiler accepts this code.
+      ComposableViewStubWrapper(update = Update(rendering, viewEnvironment))
+    }
+  }
+}
+
+/**
+ * Wraps a [WorkflowViewStub] with an API that is more Compose-friendly.
+ *
+ * In particular, Compose will only generate `Emittable`s for views with a single constructor
+ * that takes a [Context].
+ *
+ * See [this slack message](https://kotlinlang.slack.com/archives/CJLTWPH7S/p1576264533012000?thread_ts=1576262311.008800&cid=CJLTWPH7S).
+ */
+private class ComposableViewStubWrapper(context: Context) : FrameLayout(context) {
+
+  data class Update(
+    val rendering: Any,
+    val viewEnvironment: ViewEnvironment
+  )
+
+  private val viewStub = WorkflowViewStub(context)
+
+  init {
+    addView(viewStub)
+  }
+
+  // Compose turns this into a parameter when you invoke this class as a Composable.
+  fun setUpdate(update: Update) {
+    viewStub.update(update.rendering, update.viewEnvironment)
+  }
+
+  override fun getLayoutParams(): LayoutParams = LayoutParams(MATCH_PARENT, MATCH_PARENT)
+}

--- a/core-compose/src/main/java/com/squareup/workflow/ui/compose/ViewRegistries.kt
+++ b/core-compose/src/main/java/com/squareup/workflow/ui/compose/ViewRegistries.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.ui.compose
+
+import androidx.compose.Composable
+import androidx.compose.remember
+import androidx.ui.core.Modifier
+import com.squareup.workflow.ui.ViewEnvironment
+import com.squareup.workflow.ui.ViewFactory
+import com.squareup.workflow.ui.ViewRegistry
+
+/**
+ * Renders [rendering] into the composition using this [ViewRegistry] to determine how to draw it.
+ *
+ * To display a nested rendering from a [Composable view binding][bindCompose], use
+ * [ViewEnvironment.showRendering].
+ *
+ * @see ViewEnvironment.showRendering
+ * @see ViewFactory.showRendering
+ */
+@Composable internal fun ViewRegistry.showRendering(
+  rendering: Any,
+  hints: ViewEnvironment,
+  modifier: Modifier = Modifier
+) {
+  val renderingType = rendering::class
+  val viewFactory = remember(renderingType) { getFactoryFor(renderingType) }
+  viewFactory.showRendering(rendering, hints, modifier)
+}

--- a/samples/nested-renderings/build.gradle.kts
+++ b/samples/nested-renderings/build.gradle.kts
@@ -1,0 +1,48 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+plugins {
+  id("com.android.application")
+  kotlin("android")
+}
+
+apply(from = rootProject.file(".buildscript/android-sample-app.gradle"))
+apply(from = rootProject.file(".buildscript/android-ui-tests.gradle"))
+
+android {
+  defaultConfig {
+    applicationId = "com.squareup.sample.nestedrenderings"
+  }
+}
+
+apply(from = rootProject.file(".buildscript/configure-compose.gradle"))
+tasks.withType<KotlinCompile> {
+  kotlinOptions.apiVersion = "1.3"
+}
+
+dependencies {
+  implementation(project(":core-compose"))
+  implementation(Dependencies.AndroidX.appcompat)
+  implementation(Dependencies.Compose.foundation)
+  implementation(Dependencies.Compose.layout)
+  implementation(Dependencies.Compose.material)
+  implementation(Dependencies.Workflow.UI.coreAndroid)
+
+  androidTestImplementation(Dependencies.Compose.test)
+  androidTestImplementation(Dependencies.Test.junit)
+  androidTestImplementation(Dependencies.Test.truth)
+}

--- a/samples/nested-renderings/src/androidTest/java/com/squareup/sample/nestedrenderings/NestedRenderingsTest.kt
+++ b/samples/nested-renderings/src/androidTest/java/com/squareup/sample/nestedrenderings/NestedRenderingsTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sample.nestedrenderings
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.ui.test.android.AndroidComposeTestRule
+import androidx.ui.test.assertIsDisplayed
+import androidx.ui.test.doClick
+import androidx.ui.test.findAllByText
+import androidx.ui.test.findByText
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+private const val ADD_BUTTON_TEXT = "Add Child"
+
+@RunWith(AndroidJUnit4::class)
+class NestedRenderingsTest {
+
+  // Launches the activity.
+  @Rule @JvmField val composeRule = AndroidComposeTestRule<NestedRenderingsActivity>()
+
+  @Test fun childrenAreAddedAndRemoved() {
+    val resetButton = findByText("Reset")
+
+    findByText(ADD_BUTTON_TEXT)
+        .assertIsDisplayed()
+        .doClick()
+
+    findAllByText(ADD_BUTTON_TEXT)
+        .also { addButtons ->
+          assertThat(addButtons).hasSize(2)
+          addButtons.forEach { it.doClick() }
+        }
+
+    findAllByText(ADD_BUTTON_TEXT)
+        .also { addButtons ->
+          assertThat(addButtons).hasSize(4)
+        }
+
+    resetButton.doClick()
+    assertThat(findAllByText(ADD_BUTTON_TEXT)).hasSize(1)
+  }
+}

--- a/samples/nested-renderings/src/main/AndroidManifest.xml
+++ b/samples/nested-renderings/src/main/AndroidManifest.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2020 Square Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.squareup.sample.nestedrenderings">
+
+  <application
+      android:allowBackup="false"
+      android:label="@string/app_name"
+      android:theme="@style/AppTheme"
+      tools:ignore="GoogleAppIndexingWarning,MissingApplicationIcon">
+
+    <activity
+        android:name=".NestedRenderingsActivity"
+        android:configChanges="orientation|screenLayout|screenSize|density|fontScale|keyboardHidden">
+
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+
+    </activity>
+
+  </application>
+</manifest>

--- a/samples/nested-renderings/src/main/java/com/squareup/sample/nestedrenderings/LegacyRunner.kt
+++ b/samples/nested-renderings/src/main/java/com/squareup/sample/nestedrenderings/LegacyRunner.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sample.nestedrenderings
+
+import com.squareup.sample.nestedrenderings.RecursiveWorkflow.LegacyRendering
+import com.squareup.sample.nestedrenderings.databinding.LegacyViewBinding
+import com.squareup.workflow.ui.LayoutRunner
+import com.squareup.workflow.ui.LayoutRunner.Companion.bind
+import com.squareup.workflow.ui.ViewEnvironment
+import com.squareup.workflow.ui.ViewFactory
+
+/**
+ * A [LayoutRunner] that renders [LegacyRendering]s using the legacy view framework.
+ */
+class LegacyRunner(private val binding: LegacyViewBinding) : LayoutRunner<LegacyRendering> {
+
+  override fun showRendering(
+    rendering: LegacyRendering,
+    viewEnvironment: ViewEnvironment
+  ) {
+    binding.stub.update(rendering.rendering, viewEnvironment)
+  }
+
+  companion object : ViewFactory<LegacyRendering> by bind(
+      LegacyViewBinding::inflate, ::LegacyRunner
+  )
+}

--- a/samples/nested-renderings/src/main/java/com/squareup/sample/nestedrenderings/NestedRenderingsActivity.kt
+++ b/samples/nested-renderings/src/main/java/com/squareup/sample/nestedrenderings/NestedRenderingsActivity.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sample.nestedrenderings
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.squareup.workflow.diagnostic.SimpleLoggingDiagnosticListener
+import com.squareup.workflow.ui.ViewRegistry
+import com.squareup.workflow.ui.WorkflowRunner
+import com.squareup.workflow.ui.setContentWorkflow
+
+private val viewRegistry = ViewRegistry(
+    RecursiveViewFactory,
+    LegacyRunner
+)
+
+class NestedRenderingsActivity : AppCompatActivity() {
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    setContentWorkflow(viewRegistry) {
+      WorkflowRunner.Config(
+          RecursiveWorkflow,
+          diagnosticListener = SimpleLoggingDiagnosticListener()
+      )
+    }
+  }
+}

--- a/samples/nested-renderings/src/main/java/com/squareup/sample/nestedrenderings/RecursiveViewFactory.kt
+++ b/samples/nested-renderings/src/main/java/com/squareup/sample/nestedrenderings/RecursiveViewFactory.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("RemoveEmptyParenthesesFromAnnotationEntry")
+
+package com.squareup.sample.nestedrenderings
+
+import androidx.compose.Composable
+import androidx.compose.Providers
+import androidx.compose.ambientOf
+import androidx.compose.remember
+import androidx.ui.core.Alignment.Companion.CenterHorizontally
+import androidx.ui.core.Modifier
+import androidx.ui.foundation.Text
+import androidx.ui.graphics.Color
+import androidx.ui.graphics.compositeOver
+import androidx.ui.layout.Arrangement.SpaceEvenly
+import androidx.ui.layout.Column
+import androidx.ui.layout.FlowRow
+import androidx.ui.layout.MainAxisAlignment
+import androidx.ui.layout.SizeMode.Expand
+import androidx.ui.layout.fillMaxSize
+import androidx.ui.layout.padding
+import androidx.ui.material.Button
+import androidx.ui.material.Card
+import androidx.ui.res.dimensionResource
+import com.squareup.sample.nestedrenderings.RecursiveWorkflow.Rendering
+import com.squareup.workflow.ui.ViewEnvironment
+import com.squareup.workflow.ui.compose.bindCompose
+import com.squareup.workflow.ui.compose.showRendering
+
+/**
+ * Ambient of [Color] to use as the background color for a [RecursiveViewFactory].
+ */
+private val BackgroundColorAmbient = ambientOf { Color.Green }
+
+/**
+ * A `ViewFactory` that renders [RecursiveWorkflow.Rendering]s.
+ */
+val RecursiveViewFactory = bindCompose<Rendering> { rendering, viewEnvironment ->
+  // Every child should be drawn with a slightly-darker background color.
+  val color = BackgroundColorAmbient.current
+  val childColor = remember(color) {
+    color.copy(alpha = .9f)
+        .compositeOver(Color.Black)
+  }
+
+  Card(color = color) {
+    Column(
+        Modifier.padding(dimensionResource(R.dimen.recursive_padding))
+            .fillMaxSize(),
+        horizontalGravity = CenterHorizontally
+    ) {
+      Providers(BackgroundColorAmbient provides childColor) {
+        Children(
+            rendering.children, viewEnvironment,
+            // Pass a weight so that the column fills all the space not occupied by the buttons.
+            modifier = Modifier.weight(1f, fill = true)
+        )
+      }
+      Buttons(
+          onAdd = rendering.onAddChildClicked,
+          onReset = rendering.onResetClicked
+      )
+    }
+  }
+}
+
+@Composable private fun Children(
+  children: List<Any>,
+  viewEnvironment: ViewEnvironment,
+  modifier: Modifier
+) {
+  Column(
+      modifier = modifier,
+      verticalArrangement = SpaceEvenly,
+      horizontalGravity = CenterHorizontally
+  ) {
+    children.forEach { childRendering ->
+      viewEnvironment.showRendering(
+          childRendering,
+          // Pass a weight so all children are partitioned evenly within the total column space.
+          // Without the weight, each child is the full size of the parent.
+          modifier = Modifier.weight(1f, true)
+              .padding(dimensionResource(R.dimen.recursive_padding))
+      )
+    }
+  }
+}
+
+@Composable private fun Buttons(
+  onAdd: () -> Unit,
+  onReset: () -> Unit
+) {
+  // Use a FlowRow so the buttons will wrap when the parent is too narrow.
+  FlowRow(
+      mainAxisSize = Expand,
+      mainAxisAlignment = MainAxisAlignment.SpaceEvenly,
+      crossAxisSpacing = dimensionResource(R.dimen.recursive_padding)
+  ) {
+    Button(onClick = onAdd) {
+      Text("Add Child")
+    }
+    Button(onClick = onReset) {
+      Text("Reset")
+    }
+  }
+}

--- a/samples/nested-renderings/src/main/java/com/squareup/sample/nestedrenderings/RecursiveWorkflow.kt
+++ b/samples/nested-renderings/src/main/java/com/squareup/sample/nestedrenderings/RecursiveWorkflow.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.sample.nestedrenderings
+
+import com.squareup.sample.nestedrenderings.RecursiveWorkflow.LegacyRendering
+import com.squareup.sample.nestedrenderings.RecursiveWorkflow.Rendering
+import com.squareup.sample.nestedrenderings.RecursiveWorkflow.State
+import com.squareup.workflow.RenderContext
+import com.squareup.workflow.Snapshot
+import com.squareup.workflow.StatefulWorkflow
+import com.squareup.workflow.action
+import com.squareup.workflow.renderChild
+
+/**
+ * A simple workflow that produces [Rendering]s of zero or more children.
+ * The rendering provides event handlers for adding children and resetting child count to zero.
+ *
+ * Every other (odd) rendering in the [Rendering.children] will be wrapped with a [LegacyRendering]
+ * to force it to go through the legacy view layer. This way this sample both demonstrates pass-
+ * through Composable renderings as well as adapting in both directions.
+ */
+object RecursiveWorkflow : StatefulWorkflow<Unit, State, Nothing, Any>() {
+
+  data class State(val children: Int = 0)
+
+  /**
+   * A rendering from a [RecursiveWorkflow].
+   *
+   * @param children A list of renderings to display as children of this rendering.
+   * @param onAddChildClicked Adds a child to [children].
+   * @param onResetClicked Resets [children] to an empty list.
+   */
+  data class Rendering(
+    val children: List<Any>,
+    val onAddChildClicked: () -> Unit,
+    val onResetClicked: () -> Unit
+  )
+
+  /**
+   * Wrapper around a [Rendering] that will be implemented using a legacy view.
+   */
+  data class LegacyRendering(val rendering: Any)
+
+  override fun initialState(
+    props: Unit,
+    snapshot: Snapshot?
+  ): State = State()
+
+  override fun render(
+    props: Unit,
+    state: State,
+    context: RenderContext<State, Nothing>
+  ): Rendering {
+    return Rendering(
+        children = List(state.children) { i ->
+          val child = context.renderChild(RecursiveWorkflow, key = i.toString())
+          if (i % 2 == 0) child else LegacyRendering(child)
+        },
+        onAddChildClicked = { context.actionSink.send(addChild()) },
+        onResetClicked = { context.actionSink.send(reset()) }
+    )
+  }
+
+  override fun snapshotState(state: State): Snapshot = Snapshot.EMPTY
+
+  private fun addChild() = action {
+    nextState = nextState.copy(children = nextState.children + 1)
+  }
+
+  private fun reset() = action {
+    nextState = State()
+  }
+}

--- a/samples/nested-renderings/src/main/res/layout/legacy_view.xml
+++ b/samples/nested-renderings/src/main/res/layout/legacy_view.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2020 Square Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical"
+    >
+
+  <TextView
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="Legacy (input won't work)"
+      android:textAlignment="center"
+      />
+
+  <com.squareup.workflow.ui.WorkflowViewStub
+      android:id="@+id/stub"
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      />
+
+</LinearLayout>

--- a/samples/nested-renderings/src/main/res/values/dimens.xml
+++ b/samples/nested-renderings/src/main/res/values/dimens.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright 2020 Square Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <dimen name="recursive_padding">16dp</dimen>
+</resources>

--- a/samples/nested-renderings/src/main/res/values/strings.xml
+++ b/samples/nested-renderings/src/main/res/values/strings.xml
@@ -1,0 +1,18 @@
+<!--
+  ~ Copyright 2020 Square Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+  <string name="app_name">Nested Renderings</string>
+</resources>

--- a/samples/nested-renderings/src/main/res/values/styles.xml
+++ b/samples/nested-renderings/src/main/res/values/styles.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ Copyright 2020 Square Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<resources>
+
+  <!-- Base application theme. -->
+  <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <!-- Customize your theme here. -->
+  </style>
+
+</resources>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,5 +18,6 @@ rootProject.name = "workflow-compose"
 include(
     ":core-compose",
     ":samples:hello-compose-binding",
-    ":samples:hello-compose-rendering"
+    ":samples:hello-compose-rendering",
+    ":samples:nested-renderings"
 )


### PR DESCRIPTION
This is the Compose analog to `WorkflowViewStub`, and delegates to
`WorkflowViewStub` except when the child `ViewFactory` was also created
with `bindCompose`. In that case, it just invokes that factory's
Composable function directly to avoid jumping back out into legacy
View land.

The API is really simple: 
```kotlin
data class CardRendering(val content: Any)

val CardRenderingFactory = bindCompose<CardRendering> { rendering, env ->
  Card(modifier = Modifier.padding(8.dp)) {
    env.showRendering(rendering.content)
  }
}
```

Includes a sample that demonstrates drawing recursive composable bindings:
![image](https://user-images.githubusercontent.com/101754/81748670-1696b180-945f-11ea-9dea-b54e82b39eec.png)
