### PR TITLE
Make nested bindCompose factories child compositions of outer bindCompose factories.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -69,6 +69,7 @@ object Dependencies {
     }
 
     const val junit = "junit:junit:4.13"
+    const val kotlin = "org.jetbrains.kotlin:kotlin-test-junit:${Versions.kotlin}"
     const val truth = "com.google.truth:truth:1.0.1"
   }
 

--- a/core-compose/api/core-compose.api
+++ b/core-compose/api/core-compose.api
@@ -15,10 +15,31 @@ public abstract class com/squareup/workflow/compose/ComposeWorkflow : com/square
 	public abstract fun render (Ljava/lang/Object;Lcom/squareup/workflow/Sink;Lcom/squareup/workflow/ui/ViewEnvironment;Landroidx/compose/Composer;)V
 }
 
+public final class com/squareup/workflow/ui/compose/ComposeSupportKt {
+	public static final fun <clinit> ()V
+}
+
 public final class com/squareup/workflow/ui/compose/ComposeViewFactory : com/squareup/workflow/ui/ViewFactory {
 	public fun <init> (Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function3;)V
 	public fun buildView (Ljava/lang/Object;Lcom/squareup/workflow/ui/ViewEnvironment;Landroid/content/Context;Landroid/view/ViewGroup;)Landroid/view/View;
 	public fun getType ()Lkotlin/reflect/KClass;
+}
+
+public abstract interface class com/squareup/workflow/ui/compose/ComposeViewFactoryRoot {
+	public static final field Companion Lcom/squareup/workflow/ui/compose/ComposeViewFactoryRoot$Companion;
+	public static fun <clinit> ()V
+	public abstract fun wrap (Lkotlin/jvm/functions/Function1;Landroidx/compose/Composer;)V
+}
+
+public final class com/squareup/workflow/ui/compose/ComposeViewFactoryRoot$Companion : com/squareup/workflow/ui/ViewEnvironmentKey {
+	public static final fun <clinit> ()V
+	public fun getDefault ()Lcom/squareup/workflow/ui/compose/ComposeViewFactoryRoot;
+	public synthetic fun getDefault ()Ljava/lang/Object;
+}
+
+public final class com/squareup/workflow/ui/compose/ComposeViewFactoryRootKt {
+	public static final fun ComposeViewFactoryRoot (Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow/ui/compose/ComposeViewFactoryRoot;
+	public static final fun withComposeViewFactoryRoot (Lcom/squareup/workflow/ui/ViewEnvironment;Lkotlin/jvm/functions/Function2;)Lcom/squareup/workflow/ui/ViewEnvironment;
 }
 
 public final class com/squareup/workflow/ui/compose/ViewEnvironmentsKt {

--- a/core-compose/build.gradle.kts
+++ b/core-compose/build.gradle.kts
@@ -27,6 +27,7 @@ java {
 
 apply(from = rootProject.file(".buildscript/configure-maven-publish.gradle"))
 apply(from = rootProject.file(".buildscript/configure-android-defaults.gradle"))
+apply(from = rootProject.file(".buildscript/android-ui-tests.gradle"))
 
 apply(from = rootProject.file(".buildscript/configure-compose.gradle"))
 tasks.withType<KotlinCompile> {
@@ -42,6 +43,8 @@ dependencies {
   implementation(Dependencies.Compose.tooling)
   implementation(Dependencies.Workflow.runtime)
 
-  testImplementation(Dependencies.Test.junit)
-  testImplementation(Dependencies.Test.truth)
+  androidTestImplementation(Dependencies.Compose.test)
+  androidTestImplementation(Dependencies.Test.junit)
+  androidTestImplementation(Dependencies.Test.kotlin)
+  androidTestImplementation(Dependencies.Test.truth)
 }

--- a/core-compose/src/androidTest/AndroidManifest.xml
+++ b/core-compose/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright 2020 Square Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.squareup.workflow.ui.core.compose.test">
+
+  <application>
+    <!--  Required for createComposeRule.  -->
+    <activity
+        android:name="android.app.Activity"
+        android:theme="@android:style/Theme.Material.NoActionBar.Fullscreen" />
+  </application>
+</manifest>

--- a/core-compose/src/androidTest/java/com/squareup/workflow/ui/compose/ComposeViewFactoryRootTest.kt
+++ b/core-compose/src/androidTest/java/com/squareup/workflow/ui/compose/ComposeViewFactoryRootTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.ui.compose
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.ui.foundation.Text
+import androidx.ui.layout.Column
+import androidx.ui.semantics.Semantics
+import androidx.ui.test.assertIsDisplayed
+import androidx.ui.test.createComposeRule
+import androidx.ui.test.findByText
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertFailsWith
+
+@RunWith(AndroidJUnit4::class)
+class ComposeViewFactoryRootTest {
+
+  @Rule @JvmField val composeTestRule = createComposeRule()
+
+  @Test fun safeComposeViewFactoryRoot_wraps_content() {
+    val wrapped = ComposeViewFactoryRoot { content ->
+      Column {
+        Text("Parent")
+        content()
+      }
+    }
+    val safeRoot = SafeComposeViewFactoryRoot(wrapped)
+
+    composeTestRule.setContent {
+      safeRoot.wrap {
+        // Need an explicit semantics container, otherwise both Texts will be merged into a single
+        // Semantics object with the text "Parent\nChild".
+        Semantics(container = true) {
+          Text("Child")
+        }
+      }
+    }
+
+    findByText("Parent")
+        .assertIsDisplayed()
+    findByText("Child").assertIsDisplayed()
+  }
+
+  @Test fun safeComposeViewFactoryRoot_throws_whenChildrenNotInvoked() {
+    val wrapped = ComposeViewFactoryRoot { }
+    val safeRoot = SafeComposeViewFactoryRoot(wrapped)
+
+    val error = assertFailsWith<IllegalStateException> {
+      composeTestRule.setContent {
+        safeRoot.wrap {}
+      }
+    }
+
+    assertThat(error).hasMessageThat()
+        .isEqualTo(
+            "Expected ComposableDecorator to invoke children exactly once, but was invoked 0 times."
+        )
+  }
+
+  @Test fun safeComposeViewFactoryRoot_throws_whenChildrenInvokedMultipleTimes() {
+    val wrapped = ComposeViewFactoryRoot { children ->
+      children()
+      children()
+    }
+    val safeRoot = SafeComposeViewFactoryRoot(wrapped)
+
+    val error = assertFailsWith<IllegalStateException> {
+      composeTestRule.setContent {
+        safeRoot.wrap {
+          Text("Hello")
+        }
+      }
+    }
+
+    assertThat(error).hasMessageThat()
+        .isEqualTo(
+            "Expected ComposableDecorator to invoke children exactly once, but was invoked 2 times."
+        )
+  }
+}

--- a/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeSupport.kt
+++ b/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeSupport.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("RemoveEmptyParenthesesFromAnnotationEntry")
+
+package com.squareup.workflow.ui.compose
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.Composable
+import androidx.compose.Composition
+import androidx.compose.CompositionReference
+import androidx.compose.Recomposer
+import androidx.compose.compositionFor
+import androidx.lifecycle.LifecycleOwner
+import androidx.ui.node.UiComposer
+import com.squareup.workflow.ui.compose.ReflectionSupport.ANDROID_OWNER_CLASS
+import com.squareup.workflow.ui.compose.ReflectionSupport.androidOwnerView
+import com.squareup.workflow.ui.compose.ReflectionSupport.createOwner
+import com.squareup.workflow.ui.compose.ReflectionSupport.createWrappedContent
+import com.squareup.workflow.ui.compose.ReflectionSupport.ownerRoot
+import com.squareup.workflow.ui.core.compose.R
+
+private typealias AndroidOwner = Any
+private typealias WrappedComposition = Composition
+private typealias LayoutNode = Any
+
+private val DefaultLayoutParams = ViewGroup.LayoutParams(
+    ViewGroup.LayoutParams.WRAP_CONTENT,
+    ViewGroup.LayoutParams.WRAP_CONTENT
+)
+
+/**
+ * Copy of the built-in [setContent] function that takes an additional parent
+ * [CompositionReference]. This will eventually be built-in to Compose, but until then this function
+ * uses a bunch of reflection to access private Compose APIs.
+ *
+ * Once this ships in Compose, this whole file should be deleted.
+ *
+ * Tracked with Google [here](https://issuetracker.google.com/issues/156527485).
+ * Note that ambient _changes_ also don't seem to get propagated currently, that bug is tracked
+ * [here](https://issuetracker.google.com/issues/156527486).
+ */
+internal fun ViewGroup.setContent(
+  recomposer: Recomposer,
+  parent: CompositionReference,
+  content: @Composable() () -> Unit
+): Composition {
+  val composeView: AndroidOwner =
+    if (childCount > 0) {
+      getChildAt(0).takeIf(ANDROID_OWNER_CLASS::isInstance)
+    } else {
+      removeAllViews(); null
+    }
+        ?: createOwner(context).also { addView(androidOwnerView(it), DefaultLayoutParams) }
+  return doSetContent(context, composeView, recomposer, parent, content)
+}
+
+/**
+ * This is almost an exact copy of the private `doSetContent` function in Compose, but
+ * it also accepts a parent [CompositionReference].
+ */
+private fun doSetContent(
+  context: Context,
+  owner: AndroidOwner,
+  recomposer: Recomposer,
+  parent: CompositionReference,
+  content: @Composable() () -> Unit
+): Composition {
+  // val original = compositionFor(context, owner.root, recomposer)
+  val container = ownerRoot(owner)
+  val original = compositionFor(
+      container = container,
+      recomposer = recomposer,
+      parent = parent,
+      composerFactory = { slotTable, factoryRecomposer ->
+        UiComposer(context, container, slotTable, factoryRecomposer)
+      }
+  )
+
+  val wrapped = androidOwnerView(owner).getTag(R.id.wrapped_composition_tag)
+      as? WrappedComposition
+  // ?: WrappedComposition(owner, original).also {
+      ?: createWrappedContent(owner, original).also {
+        androidOwnerView(owner).setTag(R.id.wrapped_composition_tag, it)
+      }
+  wrapped.setContent(content)
+  return wrapped
+}
+
+private object ReflectionSupport {
+
+  val ANDROID_OWNER_CLASS = Class.forName("androidx.ui.core.AndroidOwner")
+  private val WRAPPED_COMPOSITION_CLASS = Class.forName("androidx.ui.core.WrappedComposition")
+  private val ANDROID_OWNER_KT_CLASS = Class.forName("androidx.ui.core.AndroidOwnerKt")
+
+  private val WRAPPED_COMPOSITION_CTOR =
+    WRAPPED_COMPOSITION_CLASS.getConstructor(ANDROID_OWNER_CLASS, Composition::class.java)
+
+  private val CREATE_OWNER_FUN =
+    ANDROID_OWNER_KT_CLASS.getMethod("createOwner", Context::class.java, LifecycleOwner::class.java)
+  private val ANDROID_OWNER_ROOT_GETTER = ANDROID_OWNER_CLASS.getMethod("getRoot")
+
+  init {
+    WRAPPED_COMPOSITION_CTOR.isAccessible = true
+  }
+
+  fun createOwner(context: Context): AndroidOwner =
+    CREATE_OWNER_FUN.invoke(null, context, null) as AndroidOwner
+
+  fun ownerRoot(owner: AndroidOwner): LayoutNode =
+    ANDROID_OWNER_ROOT_GETTER.invoke(owner) as LayoutNode
+
+  fun createWrappedContent(
+    owner: AndroidOwner,
+    original: Composition
+  ): WrappedComposition = WRAPPED_COMPOSITION_CTOR.newInstance(owner, original) as Composition
+
+  fun androidOwnerView(owner: AndroidOwner): View = owner as View
+}

--- a/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeViewFactoryRoot.kt
+++ b/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeViewFactoryRoot.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("RemoveEmptyParenthesesFromAnnotationEntry")
+
+package com.squareup.workflow.ui.compose
+
+import androidx.compose.Composable
+import androidx.compose.Direct
+import com.squareup.workflow.ui.ViewEnvironment
+import com.squareup.workflow.ui.ViewEnvironmentKey
+
+/**
+ * A `@Composable` function that is stored in a [ViewEnvironment] and will be used to wrap the first
+ * [bindCompose] composition. This can be used to setup any ambients that all [bindCompose]
+ * factories need access to, such as ambients that specify the UI theme.
+ *
+ * This function will called once, to wrap the _highest-level_ [bindCompose] in the tree. However,
+ * ambients are propagated down to child [bindCompose] compositions, so any ambients provided here
+ * will be available in _all_ [bindCompose] compositions.
+ */
+interface ComposeViewFactoryRoot {
+
+  @Composable fun wrap(content: @Composable() () -> Unit)
+
+  companion object : ViewEnvironmentKey<ComposeViewFactoryRoot>(ComposeViewFactoryRoot::class) {
+    override val default: ComposeViewFactoryRoot get() = NoopComposeViewFactoryRoot
+  }
+}
+
+/**
+ * Adds a [ComposeViewFactoryRoot] to this [ViewEnvironment] that uses [wrapper] to wrap the first
+ * [bindCompose] composition. See [ComposeViewFactoryRoot] for more information.
+ */
+fun ViewEnvironment.withComposeViewFactoryRoot(
+  wrapper: @Composable() (content: @Composable() () -> Unit) -> Unit
+): ViewEnvironment = this + (ComposeViewFactoryRoot to ComposeViewFactoryRoot(wrapper))
+
+// This could be inline, but that makes the Compose compiler puke.
+@Suppress("FunctionName")
+fun ComposeViewFactoryRoot(
+  wrapper: @Composable() (content: @Composable() () -> Unit) -> Unit
+): ComposeViewFactoryRoot = object : ComposeViewFactoryRoot {
+  @Composable override fun wrap(content: @Composable() () -> Unit) = wrapper(content)
+}
+
+private object NoopComposeViewFactoryRoot : ComposeViewFactoryRoot {
+  @Direct @Composable override fun wrap(content: @Composable() () -> Unit) {
+    content()
+  }
+}

--- a/core-compose/src/main/java/com/squareup/workflow/ui/compose/CompositionContinuation.kt
+++ b/core-compose/src/main/java/com/squareup/workflow/ui/compose/CompositionContinuation.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.workflow.ui.compose
+
+import androidx.compose.Composable
+import androidx.compose.CompositionReference
+import androidx.compose.Recomposer
+import androidx.compose.compositionReference
+import androidx.compose.currentComposer
+import com.squareup.workflow.ui.ViewEnvironment
+import com.squareup.workflow.ui.ViewEnvironmentKey
+
+/**
+ * Holds a [CompositionReference] and a [Recomposer] that can be used to [setContent] to create a
+ * composition that is a child of another composition. Child compositions get ambients and other
+ * compose context from their parent, which allows ambients provided around a [showRendering] call
+ * to be read by nested [bindCompose] factories.
+ *
+ * When [showRendering] is called, it will store an instance of this class in the [ViewEnvironment].
+ * [ComposeViewFactory] will then pull the continuation out of the environment and use it to link
+ * its composition to the outer one.
+ */
+internal data class CompositionContinuation(
+  val reference: CompositionReference? = null,
+  val recomposer: Recomposer? = null
+) {
+  companion object : ViewEnvironmentKey<CompositionContinuation>(
+      CompositionContinuation::class
+  ) {
+    override val default: CompositionContinuation
+      get() = CompositionContinuation()
+  }
+}
+
+/**
+ * Creates a [CompositionContinuation] from the current point in the composition and adds it to this
+ * [ViewEnvironment].
+ */
+@Composable internal fun ViewEnvironment.withCompositionContinuation(): ViewEnvironment {
+  val compositionReference = CompositionContinuation(
+      reference = compositionReference(),
+      recomposer = currentComposer.recomposer
+  )
+  return this + (CompositionContinuation to compositionReference)
+}

--- a/core-compose/src/main/java/com/squareup/workflow/ui/compose/SafeComposeViewFactoryRoot.kt
+++ b/core-compose/src/main/java/com/squareup/workflow/ui/compose/SafeComposeViewFactoryRoot.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:Suppress("RemoveEmptyParenthesesFromAnnotationEntry")
+
+package com.squareup.workflow.ui.compose
+
+import androidx.compose.Composable
+
+/**
+ * [ComposeViewFactoryRoot] that asserts that the [wrap] method invokes its children parameter
+ * exactly once, and throws an [IllegalStateException] if not.
+ */
+internal class SafeComposeViewFactoryRoot(
+  private val delegate: ComposeViewFactoryRoot
+) : ComposeViewFactoryRoot {
+
+  @Composable override fun wrap(content: @Composable() () -> Unit) {
+    var childrenCalledCount = 0
+    delegate.wrap {
+      childrenCalledCount++
+      content()
+    }
+    check(childrenCalledCount == 1) {
+      "Expected ComposableDecorator to invoke children exactly once, " +
+          "but was invoked $childrenCalledCount times."
+    }
+  }
+}

--- a/core-compose/src/main/java/com/squareup/workflow/ui/compose/ViewFactories.kt
+++ b/core-compose/src/main/java/com/squareup/workflow/ui/compose/ViewFactories.kt
@@ -48,9 +48,14 @@ import com.squareup.workflow.ui.compose.ComposableViewStubWrapper.Update
     if (this is ComposeViewFactory) {
       showRendering(rendering, viewEnvironment)
     } else {
+      // Plumb the current composition "context" through the ViewEnvironment so any nested composable
+      // factories get access to any ambients currently in effect.
+      // See setOrContinueContent().
+      val newEnvironment = viewEnvironment.withCompositionContinuation()
+
       // IntelliJ currently complains very loudly about this function call, but it actually compiles.
       // The IDE tooling isn't currently able to recognize that the Compose compiler accepts this code.
-      ComposableViewStubWrapper(update = Update(rendering, viewEnvironment))
+      ComposableViewStubWrapper(update = Update(rendering, newEnvironment))
     }
   }
 }

--- a/samples/hello-compose-binding/src/main/java/com/squareup/sample/hellocomposebinding/HelloBinding.kt
+++ b/samples/hello-compose-binding/src/main/java/com/squareup/sample/hellocomposebinding/HelloBinding.kt
@@ -30,9 +30,7 @@ import com.squareup.sample.hellocomposebinding.HelloWorkflow.Rendering
 import com.squareup.workflow.ui.compose.bindCompose
 
 val HelloBinding = bindCompose<Rendering> { rendering, _ ->
-  MaterialTheme {
-    DrawHelloRendering(rendering)
-  }
+  DrawHelloRendering(rendering)
 }
 
 @Composable

--- a/samples/hello-compose-binding/src/main/java/com/squareup/sample/hellocomposebinding/HelloBindingActivity.kt
+++ b/samples/hello-compose-binding/src/main/java/com/squareup/sample/hellocomposebinding/HelloBindingActivity.kt
@@ -17,17 +17,23 @@ package com.squareup.sample.hellocomposebinding
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.ui.material.MaterialTheme
 import com.squareup.workflow.diagnostic.SimpleLoggingDiagnosticListener
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.ViewRegistry
 import com.squareup.workflow.ui.WorkflowRunner
+import com.squareup.workflow.ui.compose.withComposeViewFactoryRoot
 import com.squareup.workflow.ui.setContentWorkflow
 
 private val viewRegistry = ViewRegistry(HelloBinding)
+private val containerHints = ViewEnvironment(viewRegistry).withComposeViewFactoryRoot { content ->
+  MaterialTheme(content = content)
+}
 
 class HelloBindingActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContentWorkflow(viewRegistry) {
+    setContentWorkflow(containerHints) {
       WorkflowRunner.Config(
           HelloWorkflow,
           diagnosticListener = SimpleLoggingDiagnosticListener()

--- a/samples/nested-renderings/src/main/java/com/squareup/sample/nestedrenderings/NestedRenderingsActivity.kt
+++ b/samples/nested-renderings/src/main/java/com/squareup/sample/nestedrenderings/NestedRenderingsActivity.kt
@@ -17,9 +17,13 @@ package com.squareup.sample.nestedrenderings
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.Providers
+import androidx.ui.graphics.Color
 import com.squareup.workflow.diagnostic.SimpleLoggingDiagnosticListener
+import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.ViewRegistry
 import com.squareup.workflow.ui.WorkflowRunner
+import com.squareup.workflow.ui.compose.withComposeViewFactoryRoot
 import com.squareup.workflow.ui.setContentWorkflow
 
 private val viewRegistry = ViewRegistry(
@@ -27,10 +31,14 @@ private val viewRegistry = ViewRegistry(
     LegacyRunner
 )
 
+private val viewEnvironment = ViewEnvironment(viewRegistry).withComposeViewFactoryRoot { content ->
+  Providers(BackgroundColorAmbient provides Color.Green, children = content)
+}
+
 class NestedRenderingsActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
-    setContentWorkflow(viewRegistry) {
+    setContentWorkflow(viewEnvironment) {
       WorkflowRunner.Config(
           RecursiveWorkflow,
           diagnosticListener = SimpleLoggingDiagnosticListener()

--- a/samples/nested-renderings/src/main/java/com/squareup/sample/nestedrenderings/RecursiveViewFactory.kt
+++ b/samples/nested-renderings/src/main/java/com/squareup/sample/nestedrenderings/RecursiveViewFactory.kt
@@ -44,7 +44,7 @@ import com.squareup.workflow.ui.compose.showRendering
 /**
  * Ambient of [Color] to use as the background color for a [RecursiveViewFactory].
  */
-private val BackgroundColorAmbient = ambientOf { Color.Green }
+val BackgroundColorAmbient = ambientOf<Color> { error("No background color specified") }
 
 /**
  * A `ViewFactory` that renders [RecursiveWorkflow.Rendering]s.


### PR DESCRIPTION
Also introduces a `ComposeViewFactoryRoot` `ViewEnvironment` key to allow
"initializing" ambients and other compose context for all nested composables. For example, you can use the dark Material theme for all your `bindCompose` factories like this:

```kotlin
val viewEnvironment = ViewEnvironment(viewRegistry)
  .withComposeViewFactoryRoot { content ->
    MaterialTheme(colors = darkColorPallette(), content = content)
  }
```

This uses some low-level Compose APIs (namely `CompositionReference`), and uses reflection to access some APIs that are currently private (but should be exposed eventually, see [this slack thread](https://kotlinlang.slack.com/archives/CJLTWPH7S/p1589399268368400?thread_ts=1589338571.354200&cid=CJLTWPH7S)). It's likely that this API will change significantly in the future, as per that thread, but that's all hidden from our public API.

Unfortunately, _changes_ to ambients in outer compositions still don't seem to get propagated to child ones, they only see the initial value. To see this bug in action, run the nested-samples demo on the `zachklipp/animate-nested-colors` branch.

Fixes #9.

| Before | After |
|--------|------|
| Composable nested under legacy view doesn't get modified color. | Both nested composables have correct color. |
| ![image](https://user-images.githubusercontent.com/101754/81869821-8bceb900-9529-11ea-9492-d3466592a5a2.png) | ![image](https://user-images.githubusercontent.com/101754/81869734-693ca000-9529-11ea-8099-8934206f512f.png) |
