### PR TITLE
Add previews to composables in samples.

### DIFF
--- a/.buildscript/android-sample-app.gradle
+++ b/.buildscript/android-sample-app.gradle
@@ -2,6 +2,7 @@ apply from: rootProject.file('.buildscript/configure-android-defaults.gradle')
 
 dependencies {
   implementation(Deps.get("androidx.appcompat"))
+  implementation(Deps.get("compose.tooling"))
   implementation(Deps.get("timber"))
   implementation(Deps.get("workflow.core"))
   implementation(Deps.get("workflow.runtime"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,19 @@ subprojects {
     jcenter()
   }
 
+  configurations.all {
+    resolutionStrategy {
+      // There's an issue with running Compose @Previews in Android Studio with newer versions of
+      // the coroutines library (exception about an unresolved symbol). Until that's fixed, we have
+      // to force the coroutines version brought in by Workflows to 1.3.0.
+      // See https://github.com/square/workflow-kotlin-compose/issues/13.
+      force(
+          "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0",
+          "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0"
+      )
+    }
+  }
+
   apply(plugin = "org.jlleitschuh.gradle.ktlint")
   apply(plugin = "io.gitlab.arturbosch.detekt")
   afterEvaluate {

--- a/samples/hello-compose-binding/build.gradle.kts
+++ b/samples/hello-compose-binding/build.gradle.kts
@@ -39,7 +39,6 @@ dependencies {
 
   implementation(Dependencies.Compose.layout)
   implementation(Dependencies.Compose.material)
-  implementation(Dependencies.Compose.tooling)
   implementation(Dependencies.Compose.foundation)
 
   androidTestImplementation(Dependencies.Compose.test)

--- a/samples/hello-compose-binding/src/main/java/com/squareup/sample/hellocomposebinding/HelloBinding.kt
+++ b/samples/hello-compose-binding/src/main/java/com/squareup/sample/hellocomposebinding/HelloBinding.kt
@@ -22,8 +22,6 @@ import androidx.ui.foundation.Clickable
 import androidx.ui.foundation.Text
 import androidx.ui.layout.fillMaxSize
 import androidx.ui.layout.wrapContentSize
-import androidx.ui.material.MaterialTheme
-import androidx.ui.material.Surface
 import androidx.ui.material.ripple.ripple
 import androidx.ui.tooling.preview.Preview
 import com.squareup.sample.hellocomposebinding.HelloWorkflow.Rendering
@@ -44,12 +42,7 @@ private fun DrawHelloRendering(rendering: Rendering) {
   }
 }
 
-@Preview(heightDp = 150)
-@Composable
-fun DrawHelloRenderingPreview() {
-  MaterialTheme {
-    Surface {
-      DrawHelloRendering(Rendering("Hello!", onClick = {}))
-    }
-  }
+@Preview(heightDp = 150, showBackground = true)
+@Composable private fun DrawHelloRenderingPreview() {
+  DrawHelloRendering(Rendering("Hello!", onClick = {}))
 }

--- a/samples/hello-compose-rendering/src/main/java/com/squareup/sample/hellocomposerendering/HelloRenderingWorkflow.kt
+++ b/samples/hello-compose-rendering/src/main/java/com/squareup/sample/hellocomposerendering/HelloRenderingWorkflow.kt
@@ -24,6 +24,7 @@ import androidx.ui.layout.fillMaxSize
 import androidx.ui.layout.wrapContentSize
 import androidx.ui.material.MaterialTheme
 import androidx.ui.material.ripple.ripple
+import androidx.ui.tooling.preview.Preview
 import com.squareup.sample.hellocomposerendering.HelloRenderingWorkflow.Toggle
 import com.squareup.workflow.Sink
 import com.squareup.workflow.compose.ComposeWorkflow
@@ -43,14 +44,26 @@ object HelloRenderingWorkflow : ComposeWorkflow<String, Toggle>() {
     outputSink: Sink<Toggle>,
     viewEnvironment: ViewEnvironment
   ) {
-    MaterialTheme {
-      Clickable(
-          onClick = { outputSink.send(Toggle) },
-          modifier = Modifier.ripple(bounded = true)
-              .fillMaxSize()
-      ) {
-        Text(props, modifier = Modifier.wrapContentSize(Alignment.Center))
-      }
+    Hello(props, onClick = { outputSink.send(Toggle) })
+  }
+}
+
+@Composable private fun Hello(
+  text: String,
+  onClick: () -> Unit
+) {
+  MaterialTheme {
+    Clickable(
+        onClick = onClick,
+        modifier = Modifier.ripple(bounded = true)
+            .fillMaxSize()
+    ) {
+      Text(text, modifier = Modifier.wrapContentSize(Alignment.Center))
     }
   }
+}
+
+@Preview(showBackground = true)
+@Composable private fun HelloRenderingWorkflowPreview() {
+  Hello("hello", onClick = {})
 }


### PR DESCRIPTION
Requires forcing the version of the coroutine libraries that the Workflow core artifacts transitively bring in down to 1.3.0, due to a bug in version dev10 of Compose (see #13, and [this slack message](https://kotlinlang.slack.com/archives/CJLTWPH7S/p1589450805381700?thread_ts=1588232959.054500&cid=CJLTWPH7S)).