### PR TITLE
Inline WorkflowViewStub logic in ViewFactory.showRendering to avoid unnecessary intermediate Views.

### DIFF
--- a/.buildscript/android-ui-tests.gradle
+++ b/.buildscript/android-ui-tests.gradle
@@ -2,6 +2,9 @@ android {
   defaultConfig {
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
+  testOptions {
+    animationsDisabled = true
+  }
 }
 
 dependencies {

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -100,9 +100,7 @@ jobs:
       fail-fast: false
       matrix:
         api-level:
-          # Tests are failing on APIs <24.
-          #- 21
-          #- 23
+          - 21
           - 24
           - 29
     steps:

--- a/core-compose/src/main/java/com/squareup/workflow/ui/compose/internal/ParentComposition.kt
+++ b/core-compose/src/main/java/com/squareup/workflow/ui/compose/internal/ParentComposition.kt
@@ -22,24 +22,22 @@ import androidx.compose.Composable
 import androidx.compose.CompositionReference
 import androidx.compose.Recomposer
 import androidx.compose.compositionReference
-import androidx.compose.currentComposer
 import androidx.ui.core.setContent
 import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.ViewEnvironmentKey
 
 /**
- * Holds a [CompositionReference] and a [Recomposer] that can be used to [setContent] to create a
- * composition that is a child of another composition. Child compositions get ambients and other
- * compose context from their parent, which allows ambients provided around a [showRendering] call
- * to be read by nested [bindCompose] factories.
+ * Holds a [CompositionReference] and that can be passed to [setOrSubcomposeContent] to create a
+ * composition that is a child of another composition. Subcompositions get ambients and other
+ * compose context from their parent, and propagate invalidations, which allows ambients provided
+ * around a [showRendering] call to be read by nested Compose-based view factories.
  *
  * When [showRendering] is called, it will store an instance of this class in the [ViewEnvironment].
- * [ComposeViewFactory] will then pull the continuation out of the environment and use it to link
- * its composition to the outer one.
+ * [ComposeViewFactory] pulls the reference out of the environment and uses it to link its
+ * composition to the outer one.
  */
-internal data class ParentComposition(
-  val reference: CompositionReference? = null,
-  val recomposer: Recomposer? = null
+internal class ParentComposition(
+  var reference: CompositionReference? = null
 ) {
   companion object : ViewEnvironmentKey<ParentComposition>(ParentComposition::class) {
     override val default: ParentComposition get() = ParentComposition()
@@ -50,31 +48,29 @@ internal data class ParentComposition(
  * Creates a [ParentComposition] from the current point in the composition and adds it to this
  * [ViewEnvironment].
  */
-@Composable internal fun ViewEnvironment.withParentComposition(): ViewEnvironment {
-  val compositionReference = ParentComposition(
-      reference = compositionReference(),
-      recomposer = currentComposer.recomposer
-  )
+@Composable internal fun ViewEnvironment.withParentComposition(
+  reference: CompositionReference = compositionReference()
+): ViewEnvironment {
+  val compositionReference = ParentComposition(reference = reference)
   return this + (ParentComposition to compositionReference)
 }
 
 /**
  * Starts composing [content] into this [ViewGroup].
  *
- * If there is a [ParentComposition] present in [initialViewEnvironment], it will start the
- * composition as a subcomposition of that continuation.
+ * If [parentComposition] is not null, [content] will be installed as a _subcomposition_ of the
+ * parent composition, meaning that it will propagate ambients and invalidation.
  *
  * This function corresponds to [withParentComposition].
  */
-internal fun ViewGroup.setOrContinueContent(
-  initialViewEnvironment: ViewEnvironment,
+internal fun ViewGroup.setOrSubcomposeContent(
+  parentComposition: CompositionReference?,
   content: @Composable() () -> Unit
 ) {
-  val (compositionReference, recomposer) = initialViewEnvironment[ParentComposition]
-  if (compositionReference != null && recomposer != null) {
+  if (parentComposition != null) {
     // Somewhere above us in the workflow rendering tree, there's another bindCompose factory.
     // We need to link to its composition reference so we inherit its ambients.
-    setContent(recomposer, compositionReference, content)
+    setContent(Recomposer.current(), parentComposition, content)
   } else {
     // This is the first bindCompose factory in the rendering tree, so it won't be a child
     // composition.

--- a/samples/nested-renderings/src/androidTest/java/com/squareup/sample/nestedrenderings/NestedRenderingsTest.kt
+++ b/samples/nested-renderings/src/androidTest/java/com/squareup/sample/nestedrenderings/NestedRenderingsTest.kt
@@ -24,7 +24,6 @@ import androidx.ui.test.assertIsDisplayed
 import androidx.ui.test.doClick
 import androidx.ui.test.findAllByText
 import androidx.ui.test.findByText
-import androidx.ui.test.last
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -49,9 +48,30 @@ class NestedRenderingsTest {
     findAllByText(ADD_BUTTON_TEXT)
         .assertCountEquals(4)
 
-    findAllByText("Reset").last()
-        .doClick()
+    resetAll()
     findAllByText(ADD_BUTTON_TEXT).assertCountEquals(1)
+  }
+
+  /**
+   * We can't rely on the order of nodes returned by [findAllByText], and the contents of the
+   * collection will change as we remove nodes, so we have to double-loop over all reset buttons and
+   * click them all until there is only one left.
+   */
+  private fun resetAll() {
+    var foundNodes = Int.MAX_VALUE
+    while (foundNodes > 1) {
+      foundNodes = 0
+      findAllByText("Reset").forEach {
+        try {
+          it.assertExists()
+        } catch (e: AssertionError) {
+          // No more reset buttons, we're done.
+          return@forEach
+        }
+        foundNodes++
+        it.doClick()
+      }
+    }
   }
 
   private fun SemanticsNodeInteractionCollection.forEach(


### PR DESCRIPTION
This is effectively the logic of `WorkflowViewStub`, but translated into Compose idioms. This approach has a few advantages:

 - Avoids extra custom views required to host `WorkflowViewStub` inside a Composition. Its trick
   of replacing itself in its parent doesn't play nice with Compose.
 - Allows us to pass the correct parent view for inflation (the root of the composition).
 - Avoids `WorkflowViewStub` having to do its own lookup to find the correct [ViewFactory], since
   we already have the correct one.

Like `WorkflowViewStub`, this function uses the `ViewFactory` to create and memoize a `View` to
display the rendering, keeps it updated with the latest `RenderingT` and `ViewEnvironment`, and
adds it to the composition.