### PR TITLE
Fix subcomposition of ComposableViewFactory and WorkflowRendering.

### DIFF
--- a/core-compose/src/androidTest/java/com/squareup/workflow/ui/compose/internal/ComposeSupportTest.kt
+++ b/core-compose/src/androidTest/java/com/squareup/workflow/ui/compose/internal/ComposeSupportTest.kt
@@ -23,10 +23,8 @@ import androidx.compose.Composable
 import androidx.compose.CompositionReference
 import androidx.compose.FrameManager
 import androidx.compose.Providers
-import androidx.compose.Recomposer
 import androidx.compose.ambientOf
 import androidx.compose.compositionReference
-import androidx.compose.currentComposer
 import androidx.compose.mutableStateOf
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.ui.foundation.Text
@@ -76,21 +74,20 @@ class ComposeSupportTest {
   }
 
   @Composable private fun LegacyHostComposable(leafContent: @Composable() () -> Unit) {
-    val wormhole = Wormhole(currentComposer.recomposer, compositionReference(), leafContent)
+    val wormhole = Wormhole(compositionReference(), leafContent)
     // This is valid Compose code, but the IDE doesn't know that yet so it will show an
     // unsuppressable error.
     WormholeView(wormhole = wormhole)
   }
 
   private class Wormhole(
-    val recomposer: Recomposer,
     val parentReference: CompositionReference,
     val childContent: @Composable() () -> Unit
   )
 
   private class WormholeView(context: Context) : FrameLayout(context) {
     fun setWormhole(wormhole: Wormhole) {
-      setContent(wormhole.recomposer, wormhole.parentReference, wormhole.childContent)
+      setContent(wormhole.parentReference, wormhole.childContent)
     }
   }
 

--- a/core-compose/src/main/java/com/squareup/workflow/ui/compose/CompositionRoot.kt
+++ b/core-compose/src/main/java/com/squareup/workflow/ui/compose/CompositionRoot.kt
@@ -26,7 +26,6 @@ import androidx.compose.staticAmbientOf
 import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.ViewRegistry
 import com.squareup.workflow.ui.compose.internal.mapFactories
-import kotlin.reflect.KClass
 
 /**
  * Used by [wrapWithRootIfNecessary] to ensure the [CompositionRoot] is only applied once.
@@ -58,12 +57,13 @@ fun ViewEnvironment.withCompositionRoot(root: CompositionRoot): ViewEnvironment 
  */
 fun ViewRegistry.withCompositionRoot(root: CompositionRoot): ViewRegistry =
   mapFactories { factory ->
-    if (factory !is ComposeViewFactory) return@mapFactories factory
+    @Suppress("UNCHECKED_CAST", "SafeCastWithReturn")
+    factory as? ComposeViewFactory<Any> ?: return@mapFactories factory
 
     @Suppress("UNCHECKED_CAST")
-    ComposeViewFactory(factory.type as KClass<Any>) { rendering, environment ->
+    ComposeViewFactory(factory.type) { rendering, environment ->
       wrapWithRootIfNecessary(root) {
-        (factory as ComposeViewFactory<Any>).content(rendering, environment)
+        factory.content(rendering, environment)
       }
     }
   }

--- a/core-compose/src/main/java/com/squareup/workflow/ui/compose/internal/ComposeSupport.kt
+++ b/core-compose/src/main/java/com/squareup/workflow/ui/compose/internal/ComposeSupport.kt
@@ -49,8 +49,7 @@ private val DefaultLayoutParams = ViewGroup.LayoutParams(
  * [here](https://issuetracker.google.com/issues/156527486).
  */
 internal fun ViewGroup.setContent(
-  recomposer: Recomposer,
-  parent: CompositionReference,
+  parent: CompositionReference?,
   content: @Composable() () -> Unit
 ): Composition {
   FrameManager.ensureStarted()
@@ -60,7 +59,7 @@ internal fun ViewGroup.setContent(
     } else {
       removeAllViews(); null
     } ?: AndroidOwner(context).also { addView(it.view, DefaultLayoutParams) }
-  return doSetContent(context, composeView, recomposer, parent, content)
+  return doSetContent(context, composeView, Recomposer.current(), parent, content)
 }
 
 /**
@@ -71,7 +70,7 @@ private fun doSetContent(
   context: Context,
   owner: AndroidOwner,
   recomposer: Recomposer,
-  parent: CompositionReference,
+  parent: CompositionReference?,
   content: @Composable() () -> Unit
 ): Composition {
   // val original = compositionFor(context, owner.root, recomposer)
@@ -100,10 +99,7 @@ private object ReflectionSupport {
 
   private val WRAPPED_COMPOSITION_CTOR =
     WRAPPED_COMPOSITION_CLASS.getConstructor(AndroidOwner::class.java, Composition::class.java)
-
-  init {
-    WRAPPED_COMPOSITION_CTOR.isAccessible = true
-  }
+        .apply { isAccessible = true }
 
   fun createWrappedContent(
     owner: AndroidOwner,

--- a/core-compose/src/main/java/com/squareup/workflow/ui/compose/internal/ParentComposition.kt
+++ b/core-compose/src/main/java/com/squareup/workflow/ui/compose/internal/ParentComposition.kt
@@ -17,63 +17,24 @@
 
 package com.squareup.workflow.ui.compose.internal
 
-import android.view.ViewGroup
-import androidx.compose.Composable
 import androidx.compose.CompositionReference
-import androidx.compose.Recomposer
-import androidx.compose.compositionReference
-import androidx.ui.core.setContent
 import com.squareup.workflow.ui.ViewEnvironment
 import com.squareup.workflow.ui.ViewEnvironmentKey
 
 /**
- * Holds a [CompositionReference] and that can be passed to [setOrSubcomposeContent] to create a
- * composition that is a child of another composition. Subcompositions get ambients and other
- * compose context from their parent, and propagate invalidations, which allows ambients provided
- * around a [WorkflowRendering] call to be read by nested Compose-based view factories.
+ * Holds a [CompositionReference] and that can be passed to [setContent] to create a composition
+ * that is a child of another composition. Subcompositions get ambients and other compose context
+ * from their parent, and propagate invalidations, which allows ambients provided around a
+ * [WorkflowRendering] call to be read by nested Compose-based view factories.
  *
- * When [WorkflowRendering] is called, it will store an instance of this class in the [ViewEnvironment].
- * [ComposeViewFactory] pulls the reference out of the environment and uses it to link its
- * composition to the outer one.
+ * When [WorkflowRendering] is called, it will store an instance of this class in the
+ * [ViewEnvironment]. `ComposeViewFactory` pulls the reference out of the environment and uses it to
+ * link its composition to the outer one.
  */
 internal class ParentComposition(
   var reference: CompositionReference? = null
 ) {
   companion object : ViewEnvironmentKey<ParentComposition>(ParentComposition::class) {
     override val default: ParentComposition get() = ParentComposition()
-  }
-}
-
-/**
- * Creates a [ParentComposition] from the current point in the composition and adds it to this
- * [ViewEnvironment].
- */
-@Composable internal fun ViewEnvironment.withParentComposition(
-  reference: CompositionReference = compositionReference()
-): ViewEnvironment {
-  val compositionReference = ParentComposition(reference = reference)
-  return this + (ParentComposition to compositionReference)
-}
-
-/**
- * Starts composing [content] into this [ViewGroup].
- *
- * If [parentComposition] is not null, [content] will be installed as a _subcomposition_ of the
- * parent composition, meaning that it will propagate ambients and invalidation.
- *
- * This function corresponds to [withParentComposition].
- */
-internal fun ViewGroup.setOrSubcomposeContent(
-  parentComposition: CompositionReference?,
-  content: @Composable() () -> Unit
-) {
-  if (parentComposition != null) {
-    // Somewhere above us in the workflow rendering tree, there's another composedViewFactory.
-    // We need to link to its composition reference so we inherit its ambients.
-    setContent(Recomposer.current(), parentComposition, content)
-  } else {
-    // This is the first composedViewFactory in the rendering tree, so it won't be a child
-    // composition.
-    setContent(Recomposer.current(), content)
   }
 }


### PR DESCRIPTION
Fixes to how subcomposition works after discussing with Leland. Fixes #27.

Currently, there are two cases for calling `ViewGroup.setContent`:
1. **Root composition (no parent `CompositionReference`).** In this case, compose
   will throw if called multiple times, so we only call it once and then use
   a `MutableState` to feed rendering updates to it.
2. **Subcomposition.** In this case, we _must_ call `setContent` again (i.e.
   manually recompose the child composition) every time the composition that
   the `CompositionReference` belongs to is recomposed. This is not documented
   anywhere, but is apparently part of the contract. In this case, we call
   `setContent` every time we get a rendering update.

This also pulls the `bindView` call back into a custom view. I'm not entirely sure
why, but there seems to be a timing issue with initializing all the composables
and views when the logic is all done inside compose. Using a custom view also means
we don't need to access `OwnerAmbient`.

**Known issues:**

 - #43: This issue did not occur with dev11, so I think it's a Compose bug. I haven't
   officially filed yet since distilling a reproducer is probably going to be a lot
   of work. This [might have already been fixed](https://kotlinlang.slack.com/archives/CJLTWPH7S/p1590802453206900?thread_ts=1590801881.206400&cid=CJLTWPH7S) in Compose master, so check again with dev13. I don't think it should block this PR either, since this code is still more correct.