### PR TITLE
Upgrade Compose to 1.0.0-alpha01.

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -19,7 +19,7 @@ import java.util.Locale.US
 import kotlin.reflect.full.declaredMembers
 
 object Versions {
-  const val compose = "0.1.0-dev16"
+  const val compose = "1.0.0-alpha01"
   const val kotlin = "1.4.0"
   const val targetSdk = 29
   const val workflow = "0.28.0"

--- a/core-compose/src/androidTest/java/com/squareup/workflow/ui/compose/ComposeViewFactoryTest.kt
+++ b/core-compose/src/androidTest/java/com/squareup/workflow/ui/compose/ComposeViewFactoryTest.kt
@@ -20,7 +20,7 @@ import android.widget.FrameLayout
 import androidx.compose.foundation.Text
 import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.viewinterop.emitView
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.ui.test.createComposeRule
 import androidx.ui.test.onNodeWithText
@@ -47,7 +47,7 @@ class ComposeViewFactoryTest {
         }
 
     composeRule.setContent {
-      emitView(::RootView) {
+      AndroidView(::RootView) {
         it.setViewEnvironment(viewEnvironment)
       }
     }

--- a/core-compose/src/androidTest/java/com/squareup/workflow/ui/compose/RenderAsStateTest.kt
+++ b/core-compose/src/androidTest/java/com/squareup/workflow/ui/compose/RenderAsStateTest.kt
@@ -124,14 +124,14 @@ class RenderAsStateTest {
     val savedValues = savedStateRegistry.performSave()
     println("saved keys: ${savedValues.keys}")
     // Relying on the int key across all runtimes is brittle, so use an explicit key.
-    val snapshot = ByteString.of(*(savedValues.getValue(SNAPSHOT_KEY) as ByteArray))
+    val snapshot = ByteString.of(*(savedValues.getValue(SNAPSHOT_KEY).single() as ByteArray))
     println("snapshot: ${snapshot.base64()}")
     assertThat(snapshot).isEqualTo(EXPECTED_SNAPSHOT)
   }
 
   @Test fun restoresSnapshot() {
     val workflow = SnapshottingWorkflow()
-    val restoreValues = mapOf(SNAPSHOT_KEY to EXPECTED_SNAPSHOT.toByteArray())
+    val restoreValues = mapOf(SNAPSHOT_KEY to listOf(EXPECTED_SNAPSHOT.toByteArray()))
     val savedStateRegistry = UiSavedStateRegistry(restoreValues) { true }
     lateinit var rendering: SnapshottedRendering
 

--- a/samples/src/main/java/com/squareup/sample/hellocompose/App.kt
+++ b/samples/src/main/java/com/squareup/sample/hellocompose/App.kt
@@ -15,7 +15,7 @@
  */
 package com.squareup.sample.hellocompose
 
-import androidx.compose.foundation.drawBorder
+import androidx.compose.foundation.border
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -35,9 +35,9 @@ private val viewEnvironment = ViewEnvironment(viewRegistry)
   MaterialTheme {
     WorkflowContainer(
         HelloWorkflow, viewEnvironment,
-        modifier = Modifier.drawBorder(
+        modifier = Modifier.border(
             shape = RoundedCornerShape(10.dp),
-            size = 10.dp,
+            width = 10.dp,
             color = Color.Magenta
         ),
         diagnosticListener = SimpleLoggingDiagnosticListener()

--- a/samples/src/main/java/com/squareup/sample/launcher/SampleLauncherApp.kt
+++ b/samples/src/main/java/com/squareup/sample/launcher/SampleLauncherApp.kt
@@ -20,6 +20,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.compose.foundation.Box
 import androidx.compose.foundation.Text
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
@@ -35,19 +36,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.drawLayer
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.gesture.rawPressStartGestureFilter
+import androidx.compose.ui.input.pointer.PointerEventPass.Initial
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.globalBounds
 import androidx.compose.ui.node.Ref
 import androidx.compose.ui.onPositioned
 import androidx.compose.ui.platform.ConfigurationAmbient
-import androidx.compose.ui.platform.PointerEventPass.PreDown
 import androidx.compose.ui.platform.ViewAmbient
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.PxBounds
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.height
-import androidx.compose.ui.unit.width
 import androidx.core.app.ActivityOptionsCompat.makeScaleUpAnimation
 import androidx.core.content.ContextCompat.startActivity
 import androidx.ui.tooling.preview.Preview
@@ -80,7 +79,7 @@ import com.squareup.sample.R.string
    * [androidx.ui.core.LayoutCoordinates.globalBounds] corresponds to the coordinates in the root
    * Android view hosting the composition.
    */
-  val globalBounds = remember { Ref<PxBounds>() }
+  val globalBounds = remember { Ref<Rect>() }
 
   ListItem(
       text = { Text(sample.name) },
@@ -88,7 +87,7 @@ import com.squareup.sample.R.string
       singleLineSecondaryText = false,
       // Animate the activities as scaling up from where the preview is drawn.
       icon = { SamplePreview(sample) { globalBounds.value = it.globalBounds } },
-      onClick = { launchSample(sample, rootView, globalBounds.value) }
+      modifier = Modifier.clickable { launchSample(sample, rootView, globalBounds.value) }
   )
 }
 
@@ -120,7 +119,7 @@ import com.squareup.sample.R.string
             modifier = Modifier
                 // Disable touch input, since this preview isn't meant to be interactive.
                 .rawPressStartGestureFilter(
-                    enabled = true, executionPass = PreDown, onPressStart = {}
+                    enabled = true, executionPass = Initial, onPressStart = {}
                 )
                 // Measure/layout the child at full screen size, and then just scale the pixels
                 // down. This way all the text and other density-dependent things get scaled
@@ -138,7 +137,7 @@ import com.squareup.sample.R.string
 private fun launchSample(
   sample: Sample,
   rootView: View,
-  sourceBounds: PxBounds?
+  sourceBounds: Rect?
 ) {
   val context = rootView.context
   val intent = Intent(context, sample.activityClass.java)

--- a/samples/src/main/java/com/squareup/sample/nestedrenderings/RecursiveViewFactory.kt
+++ b/samples/src/main/java/com/squareup/sample/nestedrenderings/RecursiveViewFactory.kt
@@ -61,7 +61,7 @@ val RecursiveViewFactory = composedViewFactory<Rendering> { rendering, viewEnvir
         .compositeOver(Color.Black)
   }
 
-  Card(color = color) {
+  Card(backgroundColor = color) {
     Column(
         Modifier.padding(dimensionResource(R.dimen.recursive_padding))
             .fillMaxSize(),


### PR DESCRIPTION
- `CoroutineContextAmbient` was removed. Found a related compiler bug and [filed](https://issuetracker.google.com/issues/165674304).
- Few other things were deprecated in trivial ways.
- Nested renderings sample crashes. Filed as #67.