### PR TITLE
Remove redundant parentheses after @Composable annotations.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,7 +99,10 @@ subprojects {
         setOf(
             // IntelliJ refuses to sort imports correctly.
             // This is a known issue: https://github.com/pinterest/ktlint/issues/527
-            "import-ordering"
+            "import-ordering",
+            // Ktlint doesn't know how to handle nullary annotations on function types, e.g.
+            // @Composable () -> Unit.
+            "paren-spacing"
         )
     )
   }

--- a/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeRendering.kt
+++ b/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeRendering.kt
@@ -32,7 +32,7 @@ import com.squareup.workflow.ui.ViewFactory
  * To use this type, make sure your `ViewRegistry` registers [Factory].
  */
 class ComposeRendering internal constructor(
-  internal val render: @Composable() (ViewEnvironment) -> Unit
+  internal val render: @Composable (ViewEnvironment) -> Unit
 ) {
   companion object {
     /**

--- a/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeViewFactory.kt
+++ b/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeViewFactory.kt
@@ -80,7 +80,7 @@ import kotlin.reflect.KClass
  * with the [CompositionRoot]. See the documentation on [CompositionRoot] for more information.
  */
 inline fun <reified RenderingT : Any> composedViewFactory(
-  noinline showRendering: @Composable() (
+  noinline showRendering: @Composable (
     rendering: RenderingT,
     environment: ViewEnvironment
   ) -> Unit
@@ -89,7 +89,7 @@ inline fun <reified RenderingT : Any> composedViewFactory(
 @PublishedApi
 internal class ComposeViewFactory<RenderingT : Any>(
   override val type: KClass<RenderingT>,
-  internal val content: @Composable() (RenderingT, ViewEnvironment) -> Unit
+  internal val content: @Composable (RenderingT, ViewEnvironment) -> Unit
 ) : ViewFactory<RenderingT> {
 
   @OptIn(ExperimentalComposeApi::class)

--- a/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeWorkflow.kt
+++ b/core-compose/src/main/java/com/squareup/workflow/ui/compose/ComposeWorkflow.kt
@@ -63,7 +63,7 @@ abstract class ComposeWorkflow<in PropsT, out OutputT : Any> :
  * Returns a [ComposeWorkflow] that renders itself using the given [render] function.
  */
 inline fun <PropsT, OutputT : Any> Workflow.Companion.composed(
-  crossinline render: @Composable() (
+  crossinline render: @Composable (
     props: PropsT,
     outputSink: Sink<OutputT>,
     environment: ViewEnvironment

--- a/core-compose/src/main/java/com/squareup/workflow/ui/compose/CompositionRoot.kt
+++ b/core-compose/src/main/java/com/squareup/workflow/ui/compose/CompositionRoot.kt
@@ -41,7 +41,7 @@ private val HasViewFactoryRootBeenApplied = staticAmbientOf { false }
  * However, ambients are propagated down to child [composedViewFactory] compositions, so any
  * ambients provided here will be available in _all_ [composedViewFactory] compositions.
  */
-typealias CompositionRoot = @Composable() (content: @Composable() () -> Unit) -> Unit
+typealias CompositionRoot = @Composable (content: @Composable () -> Unit) -> Unit
 
 /**
  * Convenience function for applying a [CompositionRoot] to this [ViewEnvironment]'s [ViewRegistry].
@@ -75,7 +75,7 @@ fun ViewRegistry.withCompositionRoot(root: CompositionRoot): ViewRegistry =
 @VisibleForTesting(otherwise = PRIVATE)
 @Composable internal fun wrapWithRootIfNecessary(
   root: CompositionRoot,
-  content: @Composable() () -> Unit
+  content: @Composable () -> Unit
 ) {
   if (HasViewFactoryRootBeenApplied.current) {
     // The only way this ambient can have the value true is if, somewhere above this point in the

--- a/samples/src/main/java/com/squareup/sample/launcher/Samples.kt
+++ b/samples/src/main/java/com/squareup/sample/launcher/Samples.kt
@@ -58,5 +58,5 @@ data class Sample(
   val name: String,
   val activityClass: KClass<out ComponentActivity>,
   val description: String,
-  val preview: @Composable() () -> Unit
+  val preview: @Composable () -> Unit
 )


### PR DESCRIPTION
These used to be required because the compiler couldn't differentiate between () for annotation params vs () for a function type, but now it can.